### PR TITLE
changed readBuffer arg to const char*

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=SafeString
-version=1.0.3
+version=1.0.4
 author=Matthew Ford
 maintainer=Matthew Ford
 sentence=A Safe, Static String library to replace Arduino String 
-paragraph=This library implemnents Safe (static) Strings which never cause reboots and has extensive debugging messages. V1.0.2,3 added == char and extra tests for Nano33
+paragraph=This library implemnents Safe (static) Strings which never cause reboots and has extensive debugging messages. V1.0.2,3 added == char and extra tests for Nano33 V1.0.4 made readBuffer arg const char*
 category=Data Processing
 url=https://github.com/PowerBroker2/SafeString
 architectures=*

--- a/src/SafeString.cpp
+++ b/src/SafeString.cpp
@@ -2726,7 +2726,7 @@ bool SafeString::nextToken(SafeString& token, char* delimiters) {
    fromIndex -- where to start reading from
    Note: if string is already full then nothing will be read and fromIndex will be returned
 */
-size_t SafeString::readBuffer(char* buffer, size_t fromIndex) {
+size_t SafeString::readBuffer(const char* buffer, size_t fromIndex) {
 	  if (!buffer) {
 #ifdef SSTRING_DEBUG
     if (debugPtr) {

--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -507,7 +507,7 @@ class SafeString : public Printable, public Print {
    fromIndex -- where to start reading from, defaults to 0 read from start of buffer
    Note: if string is already full then nothing will be read and fromIndex will be returned
 */
-    size_t readBuffer(char* buffer, size_t fromIndex = 0);
+    size_t readBuffer(const char* buffer, size_t fromIndex = 0);
     
 /**
    size_t writeBuffer(char* buffer, size_t bufsize, size_t fromSafeStringIndex)


### PR DESCRIPTION
User reported problem with 
str.readBuffer(arduinoStr.c_str());
giving error 
invalid conversion from 'const char*' to 'char*' [-fpermissive]