### PR TITLE
Add support for community RP2040 Arduion core

### DIFF
--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -131,7 +131,7 @@
 
 // to skip this for SparkFun RedboardTurbo
 #ifndef ARDUINO_SAMD_ZERO
-#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MEGAAVR) || defined(ARDUINO_ARCH_MBED_RP2040)
+#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MEGAAVR) || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
 namespace arduino {
 #endif
 #endif // #ifndef ARDUINO_SAMD_ZERO
@@ -936,7 +936,7 @@ class SafeString : public Printable, public Print {
 
 // to skip this for SparkFun RedboardTurbo
 #ifndef ARDUINO_SAMD_ZERO
-#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MEGAAVR)  || defined(ARDUINO_ARCH_MBED_RP2040)
+#if defined(ARDUINO_ARDUINO_NANO33BLE) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_MEGAAVR)  || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2040)
 } // namespace arduino
 #endif
 #endif  // #ifndef ARDUINO_SAMD_ZERO


### PR DESCRIPTION
The community Arduino core for the RP2040 has a different architecture
definition flag, add it to the header as appropriate.

As requested in https://github.com/earlephilhower/arduino-pico/pull/130