### PR TITLE
Make compatible with PlatformIO

### DIFF
--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -304,7 +304,7 @@ SafeString_ConstructorAndDebugging.ino, SafeStringFromCharArray.ino, SafeStringF
 
   
 ****************************************************************************************/
-class SafeString : public Printable, public Print {
+class SafeString : public arduino::Printable, public Print {
 
   public:
 /*********************************************

--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -304,8 +304,12 @@ SafeString_ConstructorAndDebugging.ino, SafeStringFromCharArray.ino, SafeStringF
 
   
 ****************************************************************************************/
+#ifdef PLATFORMIO
 class SafeString : public arduino::Printable, public Print {
-
+#else
+class SafeString : public Printable, public Print {
+#endif
+	
   public:
 /*********************************************
   SafeString Constructor called from <a href="#details">the four (4) macros</a> **createSafeString** or **cSF**, **createSafeStringFromCharArray** or **cSFA**, **createSafeStringFromCharPtr** or **cSFP**, **createSafeStringFromCharPtrWithSize** or **cSFPS**.


### PR DESCRIPTION
I found I couldn't build projects using this library with PlatformIO because you use Printable without prefixing the Arduino namespace to it. Simply adding this fixes it, and everything still builds successfully with the Arduino IDE.
