### PR TITLE
Fix redefinition of "bool" type in library header

### DIFF
--- a/src/SafeString.cpp
+++ b/src/SafeString.cpp
@@ -151,8 +151,8 @@ Print* SafeString::debugPtr = NULL; // nowhere to send the debug output yet
 Print* SafeString::currentOutput = &SafeString::emptyPrint; // nowhere to send Output to yet
 SafeString::noDebugPrint SafeString::emptyPrint;
 SafeString::DebugPrint SafeString::Output;
-bool SafeString::fullDebug = true; // output current contents of SafeString and input arg
-bool SafeString::classErrorFlag = false; // set true if any SafeString object has an error.
+safebool SafeString::fullDebug = true; // output current contents of SafeString and input arg
+safebool SafeString::classErrorFlag = false; // set true if any SafeString object has an error.
 
 /*  ********************************************/
 /**  Constructor                             */
@@ -169,7 +169,7 @@ bool SafeString::classErrorFlag = false; // set true if any SafeString object ha
     if maxLen == -1 then capacity == strlen(char*)  i.e. cSFP( )
     else capacity == maxLen-1;   i.e. cSFPS( )
 */
-SafeString::SafeString(size_t maxLen, char *buf, const char* cstr, const char* _name, bool _fromBuffer, bool _fromPtr) {
+SafeString::SafeString(size_t maxLen, char *buf, const char* cstr, const char* _name, safebool _fromBuffer, safebool _fromPtr) {
    errorFlag = false; // set to true if error detected, cleared on each call to hasError()
   timeoutStart_ms = 0;
   noCharsRead = 0; // number of char read on last call to readUntilToken
@@ -179,7 +179,7 @@ SafeString::SafeString(size_t maxLen, char *buf, const char* cstr, const char* _
   name = _name; // save name
   fromBuffer = _fromBuffer;
   timeoutRunning = false;
-  bool keepBufferContents = false;  
+  safebool keepBufferContents = false;  
   if ((buf != NULL) && (cstr != NULL) && (buf == cstr)) {
     keepBufferContents = true;
   }
@@ -313,7 +313,7 @@ SafeString::SafeString(size_t maxLen, char *buf, const char* cstr, const char* _
 
   // _capacity is set here
   // check available memory
-  bool memFail = false;
+  safebool memFail = false;
 #if defined(ARDUINO_ARCH_AVR)
   void *mem = malloc(_capacity); // will leave 128 for stack use
 #else
@@ -411,7 +411,7 @@ SafeString::SafeString(const SafeString& other ) {
 /**  end of Constructor methods ***********/
 
 unsigned char SafeString::errorDetected() {
-  bool rtn = classErrorFlag;
+  safebool rtn = classErrorFlag;
   classErrorFlag = false;
   return rtn;
 }
@@ -422,7 +422,7 @@ void SafeString::setError() {
 }
 
 unsigned char SafeString::hasError() {
-  bool rtn = errorFlag;
+  safebool rtn = errorFlag;
   errorFlag = false;
   return rtn;
 }
@@ -508,7 +508,7 @@ void SafeString::cleanUp() {
   if (!fromBuffer) {
     return; // skip scanning for length changes in the buffer in normal SafeString
   }
-  bool bufferOverrun = false;
+  safebool bufferOverrun = false;
   if ((_capacity > 0) && (buffer[_capacity] != '\0')) {
     setError(); // buffer overrun
     bufferOverrun = true;
@@ -541,7 +541,7 @@ void SafeString::cleanUp() {
 //   SafeString::turnOutputOff();
 // to stop all Error msgs and debug output (sets debugPtr to NULL)
 // verbose is an optional argument, if missing defaults to true, use false for compact error messages or call setVerbose(false)
-void SafeString::setOutput(Print& debugOut, bool verbose) {
+void SafeString::setOutput(Print& debugOut, safebool verbose) {
   debugPtr = &debugOut;
   fullDebug = verbose;  // the verbose argument is optional, if missing fullDebug is true
   currentOutput = debugPtr;
@@ -566,7 +566,7 @@ void SafeString::turnOutputOff() {
 //   SafeString::setVerbose(false);
 // for minimal error msgs
 // setVerbose( ) does not effect debug() methods which have their own optional verbose argument
-void SafeString::setVerbose(bool verbose) {
+void SafeString::setVerbose(safebool verbose) {
   fullDebug = verbose;
 }
 /** end of Output and debug control methods ***********/
@@ -584,14 +584,14 @@ void SafeString::setVerbose(bool verbose) {
 // This is so that if you add .debug() to Serial.println(str);  i.e.
 //    Serial.println(str.debug());
 // will work as expected
-const char* SafeString::debug(bool verbose) { // verbose optional defaults to true
+const char* SafeString::debug(safebool verbose) { // verbose optional defaults to true
   debug((const char*) NULL, verbose); // calls cleanUp();
   emptyDebugRtnBuffer[0] = '\0'; // if the last return was changed
   return emptyDebugRtnBuffer;
 }
 
 // These three versions print leading text before the debug output.
-const char* SafeString::debug(const __FlashStringHelper * pstr, bool verbose) { // verbose optional defaults to true
+const char* SafeString::debug(const __FlashStringHelper * pstr, safebool verbose) { // verbose optional defaults to true
   cleanUp();
   if (debugPtr) {
     if (pstr) {
@@ -605,7 +605,7 @@ const char* SafeString::debug(const __FlashStringHelper * pstr, bool verbose) { 
   return emptyDebugRtnBuffer;
 }
 
-const char* SafeString::debug(const char *title, bool verbose) { // verbose optional defaults to true
+const char* SafeString::debug(const char *title, safebool verbose) { // verbose optional defaults to true
   cleanUp();
   if (debugPtr) {
     if (title) {
@@ -619,7 +619,7 @@ const char* SafeString::debug(const char *title, bool verbose) { // verbose opti
   return emptyDebugRtnBuffer;
 }
 
-const char* SafeString::debug(SafeString &stitle, bool verbose) { // verbose optional defaults to true
+const char* SafeString::debug(SafeString &stitle, safebool verbose) { // verbose optional defaults to true
   cleanUp();
   stitle.cleanUp();
   if (debugPtr) {
@@ -859,15 +859,15 @@ size_t SafeString::print(double d, int decs) {
 
   Note decs is quietly limited in this method to < 7
 */
-size_t SafeString::print(double d, int decs, int width, bool forceSign) {
+size_t SafeString::print(double d, int decs, int width, safebool forceSign) {
   return printInt(d, decs, width, forceSign, false);
 }
-size_t SafeString::println(double d, int decs, int width, bool forceSign) {
+size_t SafeString::println(double d, int decs, int width, safebool forceSign) {
   return printInt(d, decs, width, forceSign, true);
 }
 
 // internal print method called by other print methods
-size_t SafeString::printInt(double d, int decs, int width, bool forceSign, bool addNL) {
+size_t SafeString::printInt(double d, int decs, int width, safebool forceSign, safebool addNL) {
   // if addNL need to allow 2 for nl in SafeString, width does not change
   size_t nlExtra = addNL ? 2 : 0;
 
@@ -1120,7 +1120,7 @@ size_t SafeString::print(const __FlashStringHelper *pstr) {
 
 // ============ protected internal print methods =============
 
-size_t SafeString::printInternal(long num, int base, bool assignOp) {
+size_t SafeString::printInternal(long num, int base, safebool assignOp) {
   cleanUp();
   createSafeString(temp, 8 * sizeof(long) + 4); // null + sign + nl
   size_t n = temp.Print::print(num, base);
@@ -1146,7 +1146,7 @@ size_t SafeString::printInternal(long num, int base, bool assignOp) {
   return n;
 }
 
-size_t SafeString::printInternal(unsigned long num, int base, bool assignOp) {
+size_t SafeString::printInternal(unsigned long num, int base, safebool assignOp) {
   cleanUp();
   createSafeString(temp, 8 * sizeof(long) + 4); // null + sign + nl
   size_t n = temp.Print::print(num, base);
@@ -1172,7 +1172,7 @@ size_t SafeString::printInternal(unsigned long num, int base, bool assignOp) {
   return n;
 }
 
-size_t SafeString::printInternal(double num, int digits, bool assignOp) {
+size_t SafeString::printInternal(double num, int digits, safebool assignOp) {
   cleanUp();
   createSafeString(temp, 8 * sizeof(long) + 4); // null + sign + nl
   if (digits > 7) {
@@ -1713,7 +1713,7 @@ SafeString & SafeString::concat(const __FlashStringHelper * pstr, size_t length)
 // ============== internal concat methods
 // concat at most length chars from cstr
 // this method applies assignOp
-SafeString & SafeString::concatInternal(const char *cstr, size_t length, bool assignOp) {
+SafeString & SafeString::concatInternal(const char *cstr, size_t length, safebool assignOp) {
 
   cleanUp();
   size_t newlen = len + length;
@@ -1791,7 +1791,7 @@ SafeString & SafeString::concatInternal(const char *cstr, size_t length, bool as
 
 // concat at most length chars
 // this method applies assignOp
-SafeString & SafeString::concatInternal(const __FlashStringHelper * pstr, size_t length, bool assignOp) {
+SafeString & SafeString::concatInternal(const __FlashStringHelper * pstr, size_t length, safebool assignOp) {
   cleanUp();
   if (!pstr) {
     setError();
@@ -1867,7 +1867,7 @@ SafeString & SafeString::concatInternal(const __FlashStringHelper * pstr, size_t
   return *this;
 }
 
-SafeString & SafeString::concatInternal(char c, bool assignOp) {
+SafeString & SafeString::concatInternal(char c, safebool assignOp) {
   cleanUp();
   if (c == '\0') {
     setError();
@@ -1904,7 +1904,7 @@ SafeString & SafeString::concatInternal(char c, bool assignOp) {
 }
 
 
-SafeString & SafeString::concatInternal(const char *cstr, bool assignOp) {
+SafeString & SafeString::concatInternal(const char *cstr, safebool assignOp) {
   cleanUp();
 
   if (!cstr) {
@@ -1928,7 +1928,7 @@ SafeString & SafeString::concatInternal(const char *cstr, bool assignOp) {
   return concatInternal(cstr, strlen(cstr), assignOp);
 }
 
-SafeString & SafeString::concatInternal(const __FlashStringHelper * pstr, bool assignOp) {
+SafeString & SafeString::concatInternal(const __FlashStringHelper * pstr, safebool assignOp) {
   cleanUp();
   if (!pstr) {
     setError();
@@ -2123,8 +2123,8 @@ unsigned char SafeString::equalsConstantTime(SafeString &s2) {
     ++p2;
   }
   //the following should force a constant time eval of the condition without a compiler "logical shortcut"
-  bool equalcond = (equalchars == len);
-  bool diffcond = (diffchars == 0);
+  safebool equalcond = (equalchars == len);
+  safebool diffcond = (diffchars == 0);
   return (unsigned char)(equalcond & diffcond); //bitwise AND
 }
 /******** end of comparison methods **************************/
@@ -4049,7 +4049,7 @@ unsigned char SafeString::toDouble(double  &d) {
 **/
 
 
-int SafeString::stoken(SafeString & token, unsigned int fromIndex, const char delimiter, bool returnEmptyFields, bool useAsDelimiters) {
+int SafeString::stoken(SafeString & token, unsigned int fromIndex, const char delimiter, safebool returnEmptyFields, safebool useAsDelimiters) {
   token.clear(); // no need to clean up token
   if (!delimiter) {
     setError();
@@ -4066,13 +4066,13 @@ int SafeString::stoken(SafeString & token, unsigned int fromIndex, const char de
   return stokenInternal(token, fromIndex, NULL, delimiter, returnEmptyFields,  useAsDelimiters);
 }
 
-int SafeString::stoken(SafeString &token, unsigned int fromIndex, SafeString &delimiters, bool returnEmptyFields, bool useAsDelimiters) {
+int SafeString::stoken(SafeString &token, unsigned int fromIndex, SafeString &delimiters, safebool returnEmptyFields, safebool useAsDelimiters) {
   token.clear(); // no need to clean up token
   delimiters.cleanUp();
   return stoken(token, fromIndex, delimiters.buffer, returnEmptyFields, useAsDelimiters); // calls cleanUp()
 }
 
-int SafeString::stoken(SafeString &token, unsigned int fromIndex, const char* delimiters, bool returnEmptyFields, bool useAsDelimiters) {
+int SafeString::stoken(SafeString &token, unsigned int fromIndex, const char* delimiters, safebool returnEmptyFields, safebool useAsDelimiters) {
   token.clear(); // no need to clean up token
   if (!delimiters) {
     setError();
@@ -4101,7 +4101,7 @@ int SafeString::stoken(SafeString &token, unsigned int fromIndex, const char* de
   return stokenInternal(token, fromIndex, delimiters, '\0', returnEmptyFields,  useAsDelimiters);
 }
 
-int SafeString::stokenInternal(SafeString &token, unsigned int fromIndex, const char* delimitersIn, char delimiterIn, bool returnEmptyFields, bool useAsDelimiters) {
+int SafeString::stokenInternal(SafeString &token, unsigned int fromIndex, const char* delimitersIn, char delimiterIn, safebool returnEmptyFields, safebool useAsDelimiters) {
   cleanUp();
   token.clear(); // no need to clean up token
   char charDelim[2];
@@ -4212,7 +4212,7 @@ int SafeString::stokenInternal(SafeString &token, unsigned int fromIndex, const 
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
 
-unsigned char SafeString::nextToken(SafeString& token, const char delimiter, bool returnEmptyFields, bool returnLastNonDelimitedToken, bool firstToken) {
+unsigned char SafeString::nextToken(SafeString& token, const char delimiter, safebool returnEmptyFields, safebool returnLastNonDelimitedToken, safebool firstToken) {
   cleanUp();
   token.clear();
   if (!delimiter) {
@@ -4238,12 +4238,12 @@ unsigned char SafeString::nextToken(SafeString& token, const char delimiter, boo
   return nextTokenInternal(token, NULL, delimiter, returnEmptyFields, returnLastNonDelimitedToken);
 }
 
-unsigned char SafeString::nextToken(SafeString& token, SafeString &delimiters, bool returnEmptyFields, bool returnLastNonDelimitedToken, bool firstToken) {
+unsigned char SafeString::nextToken(SafeString& token, SafeString &delimiters, safebool returnEmptyFields, safebool returnLastNonDelimitedToken, safebool firstToken) {
   delimiters.cleanUp();
   return nextToken(token, delimiters.buffer, returnEmptyFields, returnLastNonDelimitedToken, firstToken); // calls cleanUp()
 }
 
-unsigned char SafeString::nextToken(SafeString& token, const char* delimiters, bool returnEmptyFields, bool returnLastNonDelimitedToken, bool firstToken) {
+unsigned char SafeString::nextToken(SafeString& token, const char* delimiters, safebool returnEmptyFields, safebool returnLastNonDelimitedToken, safebool firstToken) {
   cleanUp();
   token.clear();
   if (!delimiters) {
@@ -4281,7 +4281,7 @@ unsigned char SafeString::nextToken(SafeString& token, const char* delimiters, b
   return nextTokenInternal(token, delimiters, '\0', returnEmptyFields, returnLastNonDelimitedToken);
 }
 
-bool SafeString::nextTokenInternal(SafeString& token, const char* delimitersIn, const char delimiterIn, bool returnEmptyFields, bool returnLastNonDelimitedToken) {
+safebool SafeString::nextTokenInternal(SafeString& token, const char* delimitersIn, const char delimiterIn, safebool returnEmptyFields, safebool returnLastNonDelimitedToken) {
   cleanUp();
   token.clear();
   if (isEmpty()) {
@@ -4493,7 +4493,7 @@ unsigned int SafeString::writeTo(SafeString & output, unsigned int startIdx) {
 */
 unsigned char SafeString::read(Stream& input) {
   cleanUp();
-  bool rtn = false;
+  safebool rtn = false;
   noCharsRead = 0;
   while (input.available() && (len < _capacity)) {
     int c = input.read();
@@ -4572,7 +4572,7 @@ unsigned char SafeString::readUntil(Stream& input, const char* delimiters) {
 }
 
 
-bool SafeString::readUntilInternal(Stream& input, const char* delimitersIn, const char delimiterIn) {
+safebool SafeString::readUntilInternal(Stream& input, const char* delimitersIn, const char delimiterIn) {
   cleanUp();
   char charDelim[2];
   charDelim[0] = delimiterIn;
@@ -4627,7 +4627,7 @@ bool SafeString::readUntilInternal(Stream& input, const char* delimitersIn, cons
         input - the Stream object to read from
         token - the SafeString to return the token found if any, always cleared at the start of this method
         delimiters - string of valid delimieters
-        skipToDelimiter - a bool variable to hold the skipToDelimiter state between calls
+        skipToDelimiter - a safebool variable to hold the skipToDelimiter state between calls
         echoInput - defaults to true to echo the chars read
         timeout_ms - defaults to never timeout, pass a non-zero ms to autoterminate the last token if no new chars received for that time.
 
@@ -4636,7 +4636,7 @@ bool SafeString::readUntilInternal(Stream& input, const char* delimitersIn, cons
       The delimiter is NOT included in the SafeString & token return. It will the first char of the this SafeString when readUntilToken returns true
  **/
 
-unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, const char delimiter, bool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
+unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, const char delimiter, safebool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
   if (!delimiter) {
     setError();
 #ifdef SSTRING_DEBUG
@@ -4651,12 +4651,12 @@ unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, cons
   return readUntilTokenInternal(input, token, NULL, delimiter, skipToDelimiter, echoInput, timeout_ms);
 }
 
-unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, SafeString& delimiters, bool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
+unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, SafeString& delimiters, safebool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
   delimiters.cleanUp();
   return readUntilToken(input, token, delimiters.buffer, skipToDelimiter, echoInput, timeout_ms); // calls cleanUp()
 }
 
-unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, const char* delimiters, bool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
+unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, const char* delimiters, safebool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
   if (!delimiters) {
     setError();
 #ifdef SSTRING_DEBUG
@@ -4682,7 +4682,7 @@ unsigned char SafeString::readUntilToken(Stream & input, SafeString& token, cons
   return readUntilTokenInternal(input, token, delimiters, '\0', skipToDelimiter, echoInput, timeout_ms);
 }
 
-bool SafeString::readUntilTokenInternal(Stream & input, SafeString& token, const char* delimitersIn, const char delimiterIn, bool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
+safebool SafeString::readUntilTokenInternal(Stream & input, SafeString& token, const char* delimitersIn, const char delimiterIn, safebool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms) {
   token.clear(); // always
   if ((echoInput != 0) && (echoInput != 1) && (timeout_ms == 0)) {
     setError();
@@ -4848,7 +4848,7 @@ size_t SafeString::getLastReadCount() {
 /*******************************************************/
 /** Private methods for Debug and Error support           */
 /*******************************************************/
-void SafeString::debugInternal(bool verbose) const {
+void SafeString::debugInternal(safebool verbose) const {
   if (debugPtr) {
     if (name) {
       debugPtr->print(' ');
@@ -4865,7 +4865,7 @@ void SafeString::debugInternal(bool verbose) const {
 
 // this internal msg debug does not add line indent if not fullDebug
 // always need to add debugPtr->println() at end of debug output
-void SafeString::debugInternalMsg(bool verbose) const {
+void SafeString::debugInternalMsg(safebool verbose) const {
   (void)(verbose);
 #ifdef SSTRING_DEBUG
   if (debugPtr) {
@@ -4889,7 +4889,7 @@ void SafeString::debugInternalMsg(bool verbose) const {
 #endif // SSTRING_DEBUG
 }
 
-void SafeString::debugInternalResultMsg(bool verbose) const {
+void SafeString::debugInternalResultMsg(safebool verbose) const {
   (void)(verbose);
 #ifdef SSTRING_DEBUG
   if (debugPtr) {
@@ -4965,7 +4965,7 @@ void SafeString::capError(const __FlashStringHelper * methodName, size_t neededC
 #endif
 }
 
-void SafeString::assignError(size_t neededCap, const char* cstr, const __FlashStringHelper * pstr, char c, bool numberFlag) const {
+void SafeString::assignError(size_t neededCap, const char* cstr, const __FlashStringHelper * pstr, char c, safebool numberFlag) const {
   (void)(neededCap);   (void)(cstr);   (void)(pstr);   (void)(c);   (void)(numberFlag);
 #ifdef SSTRING_DEBUG
   if (debugPtr) {

--- a/src/SafeString.h
+++ b/src/SafeString.h
@@ -96,7 +96,9 @@
 #define SafeString_class_h
 
 #if defined(ARDUINO_ARCH_SAM)
-#define bool int
+#define safebool int
+#else
+#define safebool bool
 #endif
 
 #ifdef __cplusplus
@@ -321,7 +323,7 @@ class SafeString : public Printable, public Print {
 // if _fromBuffer true and _fromPtr true, then from char*, (i.e. cSFP(sfStr,strPtr) or cSFPS(sfStr,strPtr, maxLen) and maxLen is either -1 cSFP( ) the size of the char Array pointed cSFPS 
 //    if maxLen == -1 then capacity == strlen(char*)  i.e. cSFP( )
 //    else capacity == maxLen-1;   i.e. cSFPS( )
-    explicit SafeString(unsigned int maxLen, char *buf, const char* cstr, const char* _name = NULL, bool _fromBuffer = false, bool _fromPtr = true);
+    explicit SafeString(unsigned int maxLen, char *buf, const char* cstr, const char* _name = NULL, safebool _fromBuffer = false, safebool _fromPtr = true);
     // _fromBuffer true does extra checking before each method execution for SafeStrings created from existing char[] buffers
     // _fromPtr is not checked unless _fromBuffer is true
     // _fromPtr true allows for any array size, if false prevents passing char* by checking sizeof(charArray) != sizeof(char*)
@@ -338,7 +340,7 @@ class SafeString : public Printable, public Print {
      @param debugOut - where to send the messages to, usually Serial, e.g. SafeString::setOutput(Serial);
      @param verbose - optional, if missing defaults to true, use false for compact error messages or call setVerbose(false)
     ***************/    
-    static void setOutput(Print& debugOut, bool verbose = true);
+    static void setOutput(Print& debugOut, safebool verbose = true);
     // static SafeString::DebugPrint Output;  // a Print object controlled by setOutput() / turnOutputOff() is defined at the bottom
 
     /*****************
@@ -354,7 +356,7 @@ class SafeString : public Printable, public Print {
      
      @param verbose - true for detailed error messages, else short error messages.
     ***************/    
-    static void setVerbose(bool verbose); // turn verbose error msgs on/off.  setOutput( ) sets verbose to true
+    static void setVerbose(safebool verbose); // turn verbose error msgs on/off.  setOutput( ) sets verbose to true
 
     // returns true if error detected, errors are detected even is setOutput has not been called
     // each call to hasError() clears the errorFlag
@@ -380,7 +382,7 @@ class SafeString : public Printable, public Print {
      
      @param verbose - true for detailed output including current contents
     ***************/    
-    const char* debug(bool verbose = true);
+    const char* debug(safebool verbose = true);
     
     /*****************
      Output the details about the this SafeString to the output specified by setOutput().
@@ -388,7 +390,7 @@ class SafeString : public Printable, public Print {
      @param title - the title to preceed the debug output, a space between this and the debug output
      @param verbose - true for detailed output including current contents
     ***************/    
-    const char* debug(const char* title, bool verbose = true);
+    const char* debug(const char* title, safebool verbose = true);
 
     /*****************
      Output the details about the this SafeString to the output specified by setOutput().
@@ -396,7 +398,7 @@ class SafeString : public Printable, public Print {
      @param title - the title to preceed the debug output, a space between this and the debug output
      @param verbose - true for detailed output including current contents
     ***************/    
-    const char* debug(const __FlashStringHelper *title, bool verbose = true);
+    const char* debug(const __FlashStringHelper *title, safebool verbose = true);
 
     /*****************
      Output the details about the this SafeString to the output specified by setOutput().
@@ -404,7 +406,7 @@ class SafeString : public Printable, public Print {
      @param title - the title to preceed the debug output, a space between this and the debug output
      @param verbose - true for detailed output including current contents
     ***************/    
-    const char* debug(SafeString &stitle, bool verbose = true);
+    const char* debug(SafeString &stitle, safebool verbose = true);
 
     /*****************
      Write (concatinate) a byte to this SafeString, from Print class.
@@ -520,7 +522,7 @@ class SafeString : public Printable, public Print {
     @param width - fixed width the output is to padded/limited to
     @param forceSign - optional, defaults to false, if true the + sign is added for +ve numbers
     ****************************************************************************/
-    size_t println(double d, int decs, int width, bool forceSign = false);
+    size_t println(double d, int decs, int width, safebool forceSign = false);
     
     /*************************************************************
     Prints a double (or long/int) to this SafeString padded with spaces (left or right) and limited to the specified width.
@@ -532,7 +534,7 @@ class SafeString : public Printable, public Print {
     @param width - fixed width the output is to padded/limited to
     @param forceSign - optional, defaults to false, if true the + sign is added for +ve numbers
     ****************************************************************************/
-    size_t print(double d, int decs, int width, bool forceSign = false);
+    size_t print(double d, int decs, int width, safebool forceSign = false);
 
 
 
@@ -1439,7 +1441,7 @@ class SafeString : public Printable, public Print {
                   while being consistent with the SafeString's all or nothing insertion rule<br>
                   Input argument errors return -1 and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    int stoken(SafeString & token, unsigned int fromIndex, const char delimiter, bool returnEmptyFields = false, bool useAsDelimiters = true);
+    int stoken(SafeString & token, unsigned int fromIndex, const char delimiter, safebool returnEmptyFields = false, safebool useAsDelimiters = true);
 
     /**
          break into the SafeString into tokens using the delimiters, the end of the SafeString is always a delimiter
@@ -1467,7 +1469,7 @@ class SafeString : public Printable, public Print {
                   while being consistent with the SafeString's all or nothing insertion rule<br>
                   Input argument errors return -1 and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    int stoken(SafeString & token, unsigned int fromIndex, const char* delimiters, bool returnEmptyFields = false, bool useAsDelimiters = true);
+    int stoken(SafeString & token, unsigned int fromIndex, const char* delimiters, safebool returnEmptyFields = false, safebool useAsDelimiters = true);
 
     /**
          break into the SafeString into tokens using the delimiters, the end of the SafeString is always a delimiter
@@ -1495,7 +1497,7 @@ class SafeString : public Printable, public Print {
                   while being consistent with the SafeString's all or nothing insertion rule<br>
                   Input argument errors return -1 and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    int stoken(SafeString & token, unsigned int fromIndex, SafeString & delimiters, bool returnEmptyFields = false, bool useAsDelimiters = true);
+    int stoken(SafeString & token, unsigned int fromIndex, SafeString & delimiters, safebool returnEmptyFields = false, safebool useAsDelimiters = true);
 
     /**
       returns true if a delimited token is found, removes the first delimited token from this SafeString and returns it in the token argument<br>
@@ -1522,7 +1524,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    inline unsigned char firstToken(SafeString & token, char delimiter, bool returnLastNonDelimitedToken = true) {
+    inline unsigned char firstToken(SafeString & token, char delimiter, safebool returnLastNonDelimitedToken = true) {
     	return nextToken(token,delimiter,true,returnLastNonDelimitedToken,true);
     }
 
@@ -1556,7 +1558,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    unsigned char nextToken(SafeString & token, char delimiter, bool returnEmptyFields = false, bool returnLastNonDelimitedToken = true, bool firstToken = false);
+    unsigned char nextToken(SafeString & token, char delimiter, safebool returnEmptyFields = false, safebool returnLastNonDelimitedToken = true, safebool firstToken = false);
 
     /**
       returns true if a delimited token is found, removes the first delimited token from this SafeString and returns it in the token argument<br>
@@ -1583,7 +1585,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    inline unsigned char firstToken(SafeString & token, SafeString delimiters, bool returnLastNonDelimitedToken = true) {
+    inline unsigned char firstToken(SafeString & token, SafeString delimiters, safebool returnLastNonDelimitedToken = true) {
     	return nextToken(token,delimiters,true,returnLastNonDelimitedToken,true);
     }
     
@@ -1617,7 +1619,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    unsigned char nextToken(SafeString & token, SafeString & delimiters, bool returnEmptyFields = false, bool returnLastNonDelimitedToken = true, bool firstToken = false);
+    unsigned char nextToken(SafeString & token, SafeString & delimiters, safebool returnEmptyFields = false, safebool returnLastNonDelimitedToken = true, safebool firstToken = false);
 
     /**
       returns true if a delimited token is found, removes the first delimited token from this SafeString and returns it in the token argument<br>
@@ -1644,7 +1646,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    inline unsigned char firstToken(SafeString & token, const char* delimiters, bool returnLastNonDelimitedToken = true) {
+    inline unsigned char firstToken(SafeString & token, const char* delimiters, safebool returnLastNonDelimitedToken = true) {
     	return nextToken(token,delimiters,true,returnLastNonDelimitedToken,true);
     }
     
@@ -1678,7 +1680,7 @@ class SafeString : public Printable, public Print {
                 while being consistent with the SafeString's all or nothing insertion rule<br>
                Input argument errors return false and an empty token and hasError() is set on both this SafeString and the token SafeString.
     **/
-    unsigned char nextToken(SafeString & token, const char* delimiters, bool returnEmptyFields = false, bool returnLastNonDelimitedToken = true, bool firstToken = false);
+    unsigned char nextToken(SafeString & token, const char* delimiters, safebool returnEmptyFields = false, safebool returnLastNonDelimitedToken = true, safebool firstToken = false);
 
 
     /* *** ReadFrom from SafeString, writeTo SafeString ************************/
@@ -1805,7 +1807,7 @@ class SafeString : public Printable, public Print {
       If a delimited token is found that fits in this SafeString but is too large for the token then true is returned and an empty token returned and an error raised on both this SafeString and the token<br>
       The delimiter is NOT included in the SafeString& token return. It will the first char of the this SafeString when readUntilToken returns true
     **/
-    unsigned char readUntilToken(Stream & input, SafeString & token, const char delimiter, bool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
+    unsigned char readUntilToken(Stream & input, SafeString & token, const char delimiter, safebool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
 
     /**
       returns true if a delimited token is found, else false<br>
@@ -1834,7 +1836,7 @@ class SafeString : public Printable, public Print {
       If a delimited token is found that fits in this SafeString but is too large for the token then true is returned and an empty token returned and an error raised on both this SafeString and the token<br>
       The delimiter is NOT included in the SafeString& token return. It will the first char of the this SafeString when readUntilToken returns true
     **/
-    unsigned char readUntilToken(Stream & input, SafeString & token, const char* delimiters, bool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
+    unsigned char readUntilToken(Stream & input, SafeString & token, const char* delimiters, safebool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
 
     /**
       returns true if a delimited token is found, else false<br>
@@ -1863,7 +1865,7 @@ class SafeString : public Printable, public Print {
       If a delimited token is found that fits in this SafeString but is too large for the token then true is returned and an empty token returned and an error raised on both this SafeString and the token<br>
       The delimiter is NOT included in the SafeString& token return. It will the first char of the this SafeString when readUntilToken returns true
     **/
-    unsigned char readUntilToken(Stream & input, SafeString & token, SafeString & delimiters, bool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
+    unsigned char readUntilToken(Stream & input, SafeString & token, SafeString & delimiters, safebool & skipToDelimiter, uint8_t echoInput = false, unsigned long timeout_ms = 0);
 
     /**
       returns the number of chars read on previous calls to read, readUntil or readUntilToken (includes '\0' read if any).
@@ -1877,7 +1879,7 @@ class SafeString : public Printable, public Print {
 
   protected:
     static Print* debugPtr;
-    static bool fullDebug;
+    static safebool fullDebug;
     char *buffer;          // the actual char array
     size_t _capacity; // the array length minus one (for the '\0')
     size_t len;       // the SafeString length (not counting the '\0')
@@ -1925,43 +1927,43 @@ class SafeString : public Printable, public Print {
     SafeString & concatln(char c);
     SafeString & concatln(const char *cstr, size_t length);
     void outputName() const ;
-    SafeString & concatInternal(const char *cstr, size_t length, bool assignOp = false); // concat at most length chars from cstr
-    SafeString & concatInternal(const __FlashStringHelper * str, size_t length, bool assignOp = false); // concat at most length chars
+    SafeString & concatInternal(const char *cstr, size_t length, safebool assignOp = false); // concat at most length chars from cstr
+    SafeString & concatInternal(const __FlashStringHelper * str, size_t length, safebool assignOp = false); // concat at most length chars
 
-    SafeString & concatInternal(const char *cstr, bool assignOp = false);
-    SafeString & concatInternal(char c, bool assignOp = false);
-    SafeString & concatInternal(const __FlashStringHelper * str, bool assignOp = false);
-    size_t printInternal(long, int = DEC, bool assignOp = false);
-    size_t printInternal(unsigned long, int = DEC, bool assignOp = false);
-    size_t printInternal(double, int = 2, bool assignOp = false);
+    SafeString & concatInternal(const char *cstr, safebool assignOp = false);
+    SafeString & concatInternal(char c, safebool assignOp = false);
+    SafeString & concatInternal(const __FlashStringHelper * str, safebool assignOp = false);
+    size_t printInternal(long, int = DEC, safebool assignOp = false);
+    size_t printInternal(unsigned long, int = DEC, safebool assignOp = false);
+    size_t printInternal(double, int = 2, safebool assignOp = false);
     void setError();
     void printlnErr()const ;
-    void debugInternalMsg(bool _fullDebug) const ;
+    void debugInternalMsg(safebool _fullDebug) const ;
     size_t limitedStrLen(const char* p, size_t limit);
-    size_t printInt(double d, int decs, int width, bool forceSign, bool addNL);
+    size_t printInt(double d, int decs, int width, safebool forceSign, safebool addNL);
 
   private:
-    bool readUntilTokenInternal(Stream & input, SafeString & token, const char* delimitersIn, char delimiterIn, bool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms);
-    bool readUntilInternal(Stream & input, const char* delimitersIn, char delimiterIn);
-    bool nextTokenInternal(SafeString & token, const char* delimitersIn, char delimiterIn, bool returnEmptyFields, bool returnLastNonDelimitedToken);
-    int stokenInternal(SafeString &token, unsigned int fromIndex, const char* delimitersIn, char delimiterIn, bool returnEmptyFields, bool useAsDelimiters);
-    bool fromBuffer; // true if createSafeStringFromBuffer created this object
-    bool errorFlag; // set to true if error detected, cleared on each call to hasError()
-    static bool classErrorFlag; // set to true if any error detected in any SafeString, cleared on each call to SafeString::errorDetected()
+    safebool readUntilTokenInternal(Stream & input, SafeString & token, const char* delimitersIn, char delimiterIn, safebool & skipToDelimiter, uint8_t echoInput, unsigned long timeout_ms);
+    safebool readUntilInternal(Stream & input, const char* delimitersIn, char delimiterIn);
+    safebool nextTokenInternal(SafeString & token, const char* delimitersIn, char delimiterIn, safebool returnEmptyFields, safebool returnLastNonDelimitedToken);
+    int stokenInternal(SafeString &token, unsigned int fromIndex, const char* delimitersIn, char delimiterIn, safebool returnEmptyFields, safebool useAsDelimiters);
+    safebool fromBuffer; // true if createSafeStringFromBuffer created this object
+    safebool errorFlag; // set to true if error detected, cleared on each call to hasError()
+    static safebool classErrorFlag; // set to true if any error detected in any SafeString, cleared on each call to SafeString::errorDetected()
     void cleanUp(); // reterminates buffer at capacity and resets len to current strlen
     const char *name;
     unsigned long timeoutStart_ms;
-    bool timeoutRunning;
+    safebool timeoutRunning;
     size_t noCharsRead; // number of char read on last call to readUntilToken
     static char nullBufferSafeStringBuffer[1];
     static char emptyDebugRtnBuffer[1];
-    void debugInternal(bool _fullDebug) const ;
-    void debugInternalResultMsg(bool _fullDebug) const ;
+    void debugInternal(safebool _fullDebug) const ;
+    void debugInternalResultMsg(safebool _fullDebug) const ;
     void concatErr()const ;
     void concatAssignError() const;
     void prefixErr()const ;
     void capError(const __FlashStringHelper * methodName, size_t neededCap, const char* cstr, const __FlashStringHelper *pstr = NULL, char c = '\0', size_t length = 0)const ;
-    void assignError(size_t neededCap, const char* cstr, const __FlashStringHelper *pstr = NULL, char c = '\0', bool numberFlag = false) const;
+    void assignError(size_t neededCap, const char* cstr, const __FlashStringHelper *pstr = NULL, char c = '\0', safebool numberFlag = false) const;
     void errorMethod(const __FlashStringHelper * methodName) const ;
     void warningMethod(const __FlashStringHelper * methodName) const ;
     void assignErrorMethod() const ;

--- a/src/SafeStringReader.cpp
+++ b/src/SafeStringReader.cpp
@@ -14,17 +14,17 @@
 #include "SafeStringNameSpace.h"
 
 // here buffSize is max size of the token + 1 for delimiter + 1 for terminating '\0;
-SafeStringReader::SafeStringReader(SafeString &sfInput_, size_t bufSize, char* tokenBuffer, const char* _name, const char delimiter, bool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) : SafeString(bufSize, tokenBuffer, "", _name) {
+SafeStringReader::SafeStringReader(SafeString &sfInput_, size_t bufSize, char* tokenBuffer, const char* _name, const char delimiter, safebool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) : SafeString(bufSize, tokenBuffer, "", _name) {
   internalCharDelimiter[0] = delimiter;
   internalCharDelimiter[1] = '\0';
   init(sfInput_, internalCharDelimiter, skipToDelimiterFlag_, echoInput_, timeout_ms_);	
 }	
 
-SafeStringReader::SafeStringReader(SafeString &sfInput_, size_t bufSize, char* tokenBuffer, const char* _name, const char* delimiters_, bool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) : SafeString(bufSize, tokenBuffer, "", _name) {
+SafeStringReader::SafeStringReader(SafeString &sfInput_, size_t bufSize, char* tokenBuffer, const char* _name, const char* delimiters_, safebool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) : SafeString(bufSize, tokenBuffer, "", _name) {
   init(sfInput_, delimiters_, skipToDelimiterFlag_, echoInput_, timeout_ms_);
 }
 	
-void SafeStringReader::init(SafeString& sfInput_,const char* delimiters_, bool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) {
+void SafeStringReader::init(SafeString& sfInput_,const char* delimiters_, safebool skipToDelimiterFlag_, uint8_t echoInput_, unsigned long timeout_ms_) {
   sfInputPtr = &sfInput_;
   delimiters = delimiters_;
   end();  // end needs delimiters set!!
@@ -38,7 +38,7 @@ void SafeStringReader::init(SafeString& sfInput_,const char* delimiters_, bool s
   charCounter = 0;
 }
 
-bool SafeStringReader::isSkippingToDelimiter() {
+safebool SafeStringReader::isSkippingToDelimiter() {
 	return (flagFlushInput || skipToDelimiterFlag);
 }
 
@@ -50,13 +50,13 @@ void SafeStringReader::connect(Stream& stream) {
   }
 }
 
-void SafeStringReader::returnEmptyTokens(bool flag) {
+void SafeStringReader::returnEmptyTokens(safebool flag) {
 	emptyTokensReturned = flag;
 }
 	
-bool SafeStringReader::end() {
+safebool SafeStringReader::end() {
 	// skip multiple delimiters and return last one
-  bool rtn = sfInputPtr->nextToken(*this, delimiters, false, true);
+  safebool rtn = sfInputPtr->nextToken(*this, delimiters, false, true);
 //  if (!rtn && (!sfInputPtr->isEmpty())) {
 //	sfInputPtr->concat(delimiters[0]);
 //	rtn =sfInputPtr->nextToken(*this, delimiters);
@@ -145,7 +145,7 @@ void SafeStringReader::flushInput() {
 
 // Each call to this method removes the lead delimiter so if you need to check the delimiter do it BEFORE the next call to read()
 // NOTE: this call always clears the SafeStringReader so no need to call clear() on sfReader at end of processing.
-bool SafeStringReader::read() {
+safebool SafeStringReader::read() {
   if (!streamPtr) {
     SafeString::Output.println();
     SafeString::Output.println(F("SafeStringReader Error: need to call connect(...); first in setup()"));
@@ -154,9 +154,9 @@ bool SafeStringReader::read() {
     delay(5000);
     return false;
   }
-  bool skipMsg = false;
-  bool rtn = false;
-  bool skipToDelimiterPrior = skipToDelimiterFlag;
+  safebool skipMsg = false;
+  safebool rtn = false;
+  safebool skipToDelimiterPrior = skipToDelimiterFlag;
   rtn = sfInputPtr->readUntilToken(*streamPtr, *this, delimiters, skipToDelimiterFlag, echoInput, timeout_ms);
   charCounter += sfInputPtr->getLastReadCount();
   if ((!skipToDelimiterPrior) && skipToDelimiterFlag) {
@@ -193,20 +193,20 @@ bool SafeStringReader::read() {
 // This is so that if you add .debugInputBuffer() to Serial.println(sfReader);  i.e.
 //    Serial.println(sfReader.debugInputBuffer());
 // will work as expected
-const char* SafeStringReader::debugInputBuffer(bool verbose) { // verbose optional defaults to true
+const char* SafeStringReader::debugInputBuffer(safebool verbose) { // verbose optional defaults to true
   return sfInputPtr->debug(verbose);
 }
 
 // These three versions print leading text before the debug output.
-const char* SafeStringReader::debugInputBuffer(const __FlashStringHelper * pstr, bool verbose) { // verbose optional defaults to true
+const char* SafeStringReader::debugInputBuffer(const __FlashStringHelper * pstr, safebool verbose) { // verbose optional defaults to true
   return sfInputPtr->debug(pstr, verbose);
 }
 
-const char* SafeStringReader::debugInputBuffer(const char *title, bool verbose) { // verbose optional defaults to true
+const char* SafeStringReader::debugInputBuffer(const char *title, safebool verbose) { // verbose optional defaults to true
   return sfInputPtr->debug(title, verbose);
 }
 
-const char* SafeStringReader::debugInputBuffer(SafeString &stitle, bool verbose) { // verbose optional defaults to true
+const char* SafeStringReader::debugInputBuffer(SafeString &stitle, safebool verbose) { // verbose optional defaults to true
   return sfInputPtr->debug(stitle, verbose);
 }
 

--- a/src/SafeStringReader.h
+++ b/src/SafeStringReader.h
@@ -73,8 +73,8 @@
 class SafeStringReader : public SafeString {
   public:
   	  // here buffSize is max size of the token + 1 for delimiter + 1 for terminating '\0;
-    explicit SafeStringReader(SafeString& _sfInput, size_t bufSize, char *tokenBuf, const char* _name, const char* delimiters, bool skipToDelimiterFlag = false, uint8_t echoInput = false, unsigned long timeout_ms = 0 );
-    explicit SafeStringReader(SafeString& _sfInput, size_t bufSize, char *tokenBuf, const char* _name, const char delimiter, bool skipToDelimiterFlag = false, uint8_t echoInput = false, unsigned long timeout_ms = 0 );
+    explicit SafeStringReader(SafeString& _sfInput, size_t bufSize, char *tokenBuf, const char* _name, const char* delimiters, safebool skipToDelimiterFlag = false, uint8_t echoInput = false, unsigned long timeout_ms = 0 );
+    explicit SafeStringReader(SafeString& _sfInput, size_t bufSize, char *tokenBuf, const char* _name, const char delimiter, safebool skipToDelimiterFlag = false, uint8_t echoInput = false, unsigned long timeout_ms = 0 );
 
     /**
           connect(Stream& stream)
@@ -103,7 +103,7 @@ class SafeStringReader : public SafeString {
       returnEmptyTokens() controls if empty tokens are returned. Default is to not return empty tokens, i.e. skip multiple consecutive delimiters.
       NOTE: this call always clears the SafeStringReader so no need to call clear() on sfReader at end of processing.
     */
-    bool read();
+    safebool read();
 
     /**
       getDelimiter()
@@ -136,7 +136,7 @@ class SafeStringReader : public SafeString {
          returnEmptyTokens() or returnEmptyTokens(true) will return a token for every delimiter found (and every timeout)
          returnEmptyTokens(false) restores the default
     */
-    void returnEmptyTokens(bool flag = true);
+    void returnEmptyTokens(safebool flag = true);
 
     /**
         end()
@@ -144,7 +144,7 @@ class SafeStringReader : public SafeString {
         disconnect from stream, turn echo off, set timeout to 0 and clear skipToDelimiter,
         clears getReadCount()
     */
-    bool end();
+    safebool end();
 
     /**
       getReadCount()
@@ -164,7 +164,7 @@ class SafeStringReader : public SafeString {
     /**
       isSkippingToDelimiter returns true if currently skipping to next delimiter
       */
-    bool isSkippingToDelimiter();
+    safebool isSkippingToDelimiter();
 
     /* Assignment operators **********************************
       Set the SafeString to a char version of the assigned value.
@@ -190,23 +190,23 @@ class SafeStringReader : public SafeString {
       These methods let you print out the current contents of the input buffer that the Stream is read into while
       waiting to read a delimiter to terminate the current token.
     */
-    const char* debugInputBuffer(bool verbose = true);
-    const char* debugInputBuffer(const char* title, bool verbose = true);
-    const char* debugInputBuffer(const __FlashStringHelper *title, bool verbose = true);
-    const char* debugInputBuffer(SafeString &stitle, bool verbose = true);
+    const char* debugInputBuffer(safebool verbose = true);
+    const char* debugInputBuffer(const char* title, safebool verbose = true);
+    const char* debugInputBuffer(const __FlashStringHelper *title, safebool verbose = true);
+    const char* debugInputBuffer(SafeString &stitle, safebool verbose = true);
 
   private:
     SafeStringReader(const SafeStringReader& other);
-    void init(SafeString& _sfInput, const char* delimiters, bool skipToDelimiterFlag, uint8_t echoInput, unsigned long timeout_ms);
+    void init(SafeString& _sfInput, const char* delimiters, safebool skipToDelimiterFlag, uint8_t echoInput, unsigned long timeout_ms);
     //  void bufferInput(); // get more input
     SafeString* sfInputPtr;
     const char* delimiters;
-    bool skipToDelimiterFlag;
-    bool echoInput;
-    bool emptyTokensReturned; // default false
-    bool flagFlushInput; // true if flushing
+    safebool skipToDelimiterFlag;
+    safebool echoInput;
+    safebool emptyTokensReturned; // default false
+    safebool flagFlushInput; // true if flushing
     unsigned long timeout_ms;
-    bool haveToken; // true if have token but read() not called yet
+    safebool haveToken; // true if have token but read() not called yet
     Stream *streamPtr;
     size_t charCounter; // counts bytes read, useful for http streams
     char internalCharDelimiter[2]; // used if char delimiter passed


### PR DESCRIPTION
When including "Safestring.h" library for an `ARDUINO_ARCH_SAM`, boolean type is redefined to an integer. This will pollute our sketch since this redefinition is inside the header.  
Fix it by using a custom boolean type name for this library